### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/venv/Lib/site-packages/ag2-0.5.3.dist-info/METADATA
+++ b/venv/Lib/site-packages/ag2-0.5.3.dist-info/METADATA
@@ -1,7 +1,7 @@
 Metadata-Version: 2.1
 Name: ag2
 Version: 0.5.3
-Summary: Alias package for pyautogen
+Summary: Alias package for ag2
 Home-page: https://github.com/ag2ai/ag2
 Author: Chi Wang & Qingyun Wu
 Author-email: support@ag2.ai
@@ -14,71 +14,71 @@ Requires-Python: >=3.8,<3.14
 Description-Content-Type: text/markdown
 License-File: LICENSE
 License-File: NOTICE.md
-Requires-Dist: pyautogen (==0.5.3)
+Requires-Dist: ag2 (==0.5.3)
 Provides-Extra: anthropic
-Requires-Dist: pyautogen[anthropic] (==0.5.3) ; extra == 'anthropic'
+Requires-Dist: ag2[anthropic] (==0.5.3) ; extra == 'anthropic'
 Provides-Extra: autobuild
-Requires-Dist: pyautogen[autobuild] (==0.5.3) ; extra == 'autobuild'
+Requires-Dist: ag2[autobuild] (==0.5.3) ; extra == 'autobuild'
 Provides-Extra: bedrock
-Requires-Dist: pyautogen[bedrock] (==0.5.3) ; extra == 'bedrock'
+Requires-Dist: ag2[bedrock] (==0.5.3) ; extra == 'bedrock'
 Provides-Extra: blendsearch
-Requires-Dist: pyautogen[blendsearch] (==0.5.3) ; extra == 'blendsearch'
+Requires-Dist: ag2[blendsearch] (==0.5.3) ; extra == 'blendsearch'
 Provides-Extra: captainagent
-Requires-Dist: pyautogen[captainagent] (==0.5.3) ; extra == 'captainagent'
+Requires-Dist: ag2[captainagent] (==0.5.3) ; extra == 'captainagent'
 Provides-Extra: cerebras
-Requires-Dist: pyautogen[cerebras] (==0.5.3) ; extra == 'cerebras'
+Requires-Dist: ag2[cerebras] (==0.5.3) ; extra == 'cerebras'
 Provides-Extra: cohere
-Requires-Dist: pyautogen[cohere] (==0.5.3) ; extra == 'cohere'
+Requires-Dist: ag2[cohere] (==0.5.3) ; extra == 'cohere'
 Provides-Extra: cosmosdb
-Requires-Dist: pyautogen[cosmosdb] (==0.5.3) ; extra == 'cosmosdb'
+Requires-Dist: ag2[cosmosdb] (==0.5.3) ; extra == 'cosmosdb'
 Provides-Extra: gemini
-Requires-Dist: pyautogen[gemini] (==0.5.3) ; extra == 'gemini'
+Requires-Dist: ag2[gemini] (==0.5.3) ; extra == 'gemini'
 Provides-Extra: graph
-Requires-Dist: pyautogen[graph] (==0.5.3) ; extra == 'graph'
+Requires-Dist: ag2[graph] (==0.5.3) ; extra == 'graph'
 Provides-Extra: graph-rag-falkor-db
-Requires-Dist: pyautogen[graph-rag-falkor-db] (==0.5.3) ; extra == 'graph-rag-falkor-db'
+Requires-Dist: ag2[graph-rag-falkor-db] (==0.5.3) ; extra == 'graph-rag-falkor-db'
 Provides-Extra: groq
-Requires-Dist: pyautogen[groq] (==0.5.3) ; extra == 'groq'
+Requires-Dist: ag2[groq] (==0.5.3) ; extra == 'groq'
 Provides-Extra: jupyter-executor
-Requires-Dist: pyautogen[jupyter-executor] (==0.5.3) ; extra == 'jupyter-executor'
+Requires-Dist: ag2[jupyter-executor] (==0.5.3) ; extra == 'jupyter-executor'
 Provides-Extra: lmm
-Requires-Dist: pyautogen[lmm] (==0.5.3) ; extra == 'lmm'
+Requires-Dist: ag2[lmm] (==0.5.3) ; extra == 'lmm'
 Provides-Extra: long-context
-Requires-Dist: pyautogen[long-context] (==0.5.3) ; extra == 'long-context'
+Requires-Dist: ag2[long-context] (==0.5.3) ; extra == 'long-context'
 Provides-Extra: mathchat
-Requires-Dist: pyautogen[mathchat] (==0.5.3) ; extra == 'mathchat'
+Requires-Dist: ag2[mathchat] (==0.5.3) ; extra == 'mathchat'
 Provides-Extra: mistral
-Requires-Dist: pyautogen[mistral] (==0.5.3) ; extra == 'mistral'
+Requires-Dist: ag2[mistral] (==0.5.3) ; extra == 'mistral'
 Provides-Extra: neo4j
-Requires-Dist: pyautogen[neo4j] (==0.5.3) ; extra == 'neo4j'
+Requires-Dist: ag2[neo4j] (==0.5.3) ; extra == 'neo4j'
 Provides-Extra: ollama
-Requires-Dist: pyautogen[ollama] (==0.5.3) ; extra == 'ollama'
+Requires-Dist: ag2[ollama] (==0.5.3) ; extra == 'ollama'
 Provides-Extra: redis
-Requires-Dist: pyautogen[redis] (==0.5.3) ; extra == 'redis'
+Requires-Dist: ag2[redis] (==0.5.3) ; extra == 'redis'
 Provides-Extra: retrievechat
-Requires-Dist: pyautogen[retrievechat] (==0.5.3) ; extra == 'retrievechat'
+Requires-Dist: ag2[retrievechat] (==0.5.3) ; extra == 'retrievechat'
 Provides-Extra: retrievechat-mongodb
-Requires-Dist: pyautogen[retrievechat-mongodb] (==0.5.3) ; extra == 'retrievechat-mongodb'
+Requires-Dist: ag2[retrievechat-mongodb] (==0.5.3) ; extra == 'retrievechat-mongodb'
 Provides-Extra: retrievechat-pgvector
-Requires-Dist: pyautogen[retrievechat-pgvector] (==0.5.3) ; extra == 'retrievechat-pgvector'
+Requires-Dist: ag2[retrievechat-pgvector] (==0.5.3) ; extra == 'retrievechat-pgvector'
 Provides-Extra: retrievechat-qdrant
-Requires-Dist: pyautogen[retrievechat-qdrant] (==0.5.3) ; extra == 'retrievechat-qdrant'
+Requires-Dist: ag2[retrievechat-qdrant] (==0.5.3) ; extra == 'retrievechat-qdrant'
 Provides-Extra: teachable
-Requires-Dist: pyautogen[teachable] (==0.5.3) ; extra == 'teachable'
+Requires-Dist: ag2[teachable] (==0.5.3) ; extra == 'teachable'
 Provides-Extra: test
-Requires-Dist: pyautogen[test] (==0.5.3) ; extra == 'test'
+Requires-Dist: ag2[test] (==0.5.3) ; extra == 'test'
 Provides-Extra: together
-Requires-Dist: pyautogen[together] (==0.5.3) ; extra == 'together'
+Requires-Dist: ag2[together] (==0.5.3) ; extra == 'together'
 Provides-Extra: types
-Requires-Dist: pyautogen[types] (==0.5.3) ; extra == 'types'
+Requires-Dist: ag2[types] (==0.5.3) ; extra == 'types'
 Provides-Extra: websockets
-Requires-Dist: pyautogen[websockets] (==0.5.3) ; extra == 'websockets'
+Requires-Dist: ag2[websockets] (==0.5.3) ; extra == 'websockets'
 Provides-Extra: websurfer
-Requires-Dist: pyautogen[websurfer] (==0.5.3) ; extra == 'websurfer'
+Requires-Dist: ag2[websurfer] (==0.5.3) ; extra == 'websurfer'
 
 <a name="readme-top"></a>
 
-![Pypi Downloads](https://img.shields.io/pypi/dm/pyautogen?label=PyPI%20downloads)
+![Pypi Downloads](https://img.shields.io/pypi/dm/ag2?label=PyPI%20downloads)
 [![PyPI version](https://badge.fury.io/py/autogen.svg)](https://badge.fury.io/py/autogen)
 [![Build](https://github.com/ag2ai/ag2/actions/workflows/python-package.yml/badge.svg)](https://github.com/ag2ai/ag2/actions/workflows/python-package.yml)
 ![Python Version](https://img.shields.io/badge/3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)
@@ -103,10 +103,10 @@ Requires-Dist: pyautogen[websurfer] (==0.5.3) ; extra == 'websurfer'
 > We invite collaborators from all organizations and individuals to join the development.
 
 
-:fire: :tada: AG2 is available via `pyautogen` (or its alias  `autogen` or  `ag2`)  on PyPI!
+:fire: :tada: AG2 is available via `ag2` (or its alias  `autogen` or  `ag2`)  on PyPI!
 
 ```
-pip install pyautogen
+pip install ag2
 ```
 
 📄 **License:**
@@ -133,7 +133,7 @@ We adopt the Apache 2.0 license from v0.3. This enhances our commitment to open-
 
 :tada: Dec 31, 2023: [AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework](https://arxiv.org/abs/2308.08155) is selected by [TheSequence: My Five Favorite AI Papers of 2023](https://thesequence.substack.com/p/my-five-favorite-ai-papers-of-2023).
 
-<!-- :fire: Nov 24: pyautogen [v0.2](https://github.com/ag2ai/ag2/releases/tag/v0.2.0) is released with many updates and new features compared to v0.1.1. It switches to using openai-python v1. Please read the [migration guide](https://ag2ai.github.io/ag2/docs/Installation#python). -->
+<!-- :fire: Nov 24: ag2 [v0.2](https://github.com/ag2ai/ag2/releases/tag/v0.2.0) is released with many updates and new features compared to v0.1.1. It switches to using openai-python v1. Please read the [migration guide](https://ag2ai.github.io/ag2/docs/Installation#python). -->
 
 <!-- :fire: Nov 11: OpenAI's Assistants are available in AutoGen and interoperatable with other AutoGen agents! Checkout our [blogpost](https://ag2ai.github.io/ag2/blog/2023/11/13/OAI-assistants) for details and examples. -->
 

--- a/venv/Lib/site-packages/pyautogen-0.5.3.dist-info/METADATA
+++ b/venv/Lib/site-packages/pyautogen-0.5.3.dist-info/METADATA
@@ -1,5 +1,5 @@
 Metadata-Version: 2.1
-Name: pyautogen
+Name: ag2
 Version: 0.5.3
 Summary: A programming framework for agentic AI
 Home-page: https://github.com/ag2ai/ag2
@@ -157,7 +157,7 @@ Requires-Dist: pdfminer.six ; extra == 'websurfer'
 
 <a name="readme-top"></a>
 
-![Pypi Downloads](https://img.shields.io/pypi/dm/pyautogen?label=PyPI%20downloads)
+![Pypi Downloads](https://img.shields.io/pypi/dm/ag2?label=PyPI%20downloads)
 [![PyPI version](https://badge.fury.io/py/autogen.svg)](https://badge.fury.io/py/autogen)
 [![Build](https://github.com/ag2ai/ag2/actions/workflows/python-package.yml/badge.svg)](https://github.com/ag2ai/ag2/actions/workflows/python-package.yml)
 ![Python Version](https://img.shields.io/badge/3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)
@@ -182,10 +182,10 @@ Requires-Dist: pdfminer.six ; extra == 'websurfer'
 > We invite collaborators from all organizations and individuals to join the development.
 
 
-:fire: :tada: AG2 is available via `pyautogen` (or its alias  `autogen` or  `ag2`)  on PyPI!
+:fire: :tada: AG2 is available via `ag2` (or its alias  `autogen` or  `ag2`)  on PyPI!
 
 ```
-pip install pyautogen
+pip install ag2
 ```
 
 📄 **License:**
@@ -212,7 +212,7 @@ We adopt the Apache 2.0 license from v0.3. This enhances our commitment to open-
 
 :tada: Dec 31, 2023: [AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework](https://arxiv.org/abs/2308.08155) is selected by [TheSequence: My Five Favorite AI Papers of 2023](https://thesequence.substack.com/p/my-five-favorite-ai-papers-of-2023).
 
-<!-- :fire: Nov 24: pyautogen [v0.2](https://github.com/ag2ai/ag2/releases/tag/v0.2.0) is released with many updates and new features compared to v0.1.1. It switches to using openai-python v1. Please read the [migration guide](https://ag2ai.github.io/ag2/docs/Installation#python). -->
+<!-- :fire: Nov 24: ag2 [v0.2](https://github.com/ag2ai/ag2/releases/tag/v0.2.0) is released with many updates and new features compared to v0.1.1. It switches to using openai-python v1. Please read the [migration guide](https://ag2ai.github.io/ag2/docs/Installation#python). -->
 
 <!-- :fire: Nov 11: OpenAI's Assistants are available in AutoGen and interoperatable with other AutoGen agents! Checkout our [blogpost](https://ag2ai.github.io/ag2/blog/2023/11/13/OAI-assistants) for details and examples. -->
 

--- a/venv/Lib/site-packages/pyautogen-0.5.3.dist-info/RECORD
+++ b/venv/Lib/site-packages/pyautogen-0.5.3.dist-info/RECORD
@@ -306,10 +306,10 @@ autogen/runtime_logging.py,sha256=iAJO_oddNfItIghNlTv060Ld0NybK52SzL7qu3n0vRw,48
 autogen/token_count_utils.py,sha256=XWEqxmYd5aAg-IxpCU54G1AXT75SbFNn4ZTLUXwAPYY,10306
 autogen/types.py,sha256=zkSwYEfDePIsuk03IgutDPwb1QlFK-rAu23uYvQKrXE,601
 autogen/version.py,sha256=hB7ytg5pMMdFaA7Uyt7A68xE8XHSY3EtY7MUIkWeBSI,127
-pyautogen-0.5.3.dist-info/INSTALLER,sha256=zuuue4knoyJ-UwPPXg8fezS7VCrXJQrAP7zeNuwvFQg,4
-pyautogen-0.5.3.dist-info/LICENSE,sha256=GEFQVNayAR-S_rQD5l8hPdgvgyktVdy4Bx5-v90IfRI,11384
-pyautogen-0.5.3.dist-info/METADATA,sha256=_Q7cPaxdSOt7i03AgeNzMxwCxzDcLDoZcyRixwdvsS8,25469
-pyautogen-0.5.3.dist-info/NOTICE.md,sha256=ucvou1bE6i2s40qyuU9RL0TeIVG01VhXoQ59EngtEz4,1317
-pyautogen-0.5.3.dist-info/RECORD,,
-pyautogen-0.5.3.dist-info/WHEEL,sha256=G16H4A3IeoQmnOrYV4ueZGKSjhipXx8zc8nu9FGlvMA,92
-pyautogen-0.5.3.dist-info/top_level.txt,sha256=qRZ2MW8yuy0LtOLpeZndl4H1buusjxhwD6c9AXbVqKQ,8
+ag2-0.5.3.dist-info/INSTALLER,sha256=zuuue4knoyJ-UwPPXg8fezS7VCrXJQrAP7zeNuwvFQg,4
+ag2-0.5.3.dist-info/LICENSE,sha256=GEFQVNayAR-S_rQD5l8hPdgvgyktVdy4Bx5-v90IfRI,11384
+ag2-0.5.3.dist-info/METADATA,sha256=_Q7cPaxdSOt7i03AgeNzMxwCxzDcLDoZcyRixwdvsS8,25469
+ag2-0.5.3.dist-info/NOTICE.md,sha256=ucvou1bE6i2s40qyuU9RL0TeIVG01VhXoQ59EngtEz4,1317
+ag2-0.5.3.dist-info/RECORD,,
+ag2-0.5.3.dist-info/WHEEL,sha256=G16H4A3IeoQmnOrYV4ueZGKSjhipXx8zc8nu9FGlvMA,92
+ag2-0.5.3.dist-info/top_level.txt,sha256=qRZ2MW8yuy0LtOLpeZndl4H1buusjxhwD6c9AXbVqKQ,8


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
